### PR TITLE
fix NPE

### DIFF
--- a/extension/src/main/java/me/drakeet/support/about/extension/RecommendedLoader.java
+++ b/extension/src/main/java/me/drakeet/support/about/extension/RecommendedLoader.java
@@ -67,6 +67,10 @@ public class RecommendedLoader {
                     Log.e(TAG, "Json parse failed with null response");
                     return;
                 }
+                if (recommendedResponse.data == null) {
+                    Log.e(TAG, "Json parse failed with null data(List<Recommended>)");
+                    return;
+                }
                 activity.runOnUiThread(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
List#addAll() 
if the specified collection contains one or more null elements and this list does not permit null elements, or if the specified collection is null, will throw the NullPointerException.